### PR TITLE
Add Gradient Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ indent_size = 2
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+quote_type = single
 
 [*.md]
 insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -85,6 +85,46 @@ When you use the component with Vue 3 with `TypeScript`:
 </script>
 ```
 
+### Example Usage With Gradient
+
+To use the `QrcodeVue` component with gradient support, you can pass the gradient-related props:
+
+```html
+<template>
+  <qrcode-vue
+    :size="size"
+    :value="fullUrl"
+    :level="level"
+    :margin="margin"
+    :render-as="renderAs"
+    :background="background"
+    :gradient="true"
+    :gradient-type="gradientType"
+    :gradient-start-color="gradientStartColor"
+    :gradient-end-color="gradientEndColor"
+  />
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      size: 200,
+      fullUrl: 'https://example.com',
+      level: 'H',
+      margin: 4,
+      renderAs: 'svg', // or 'canvas'
+      background: '#ffffff',
+      gradient: true,
+      gradientType: 'linear', // or 'radial'
+      gradientStartColor: '#ff0000', // Start color of the gradient
+      gradientEndColor: '#0000ff', // End color of the gradient
+    }
+  },
+}
+</script>
+```
+
 ## Component props
 
 ### `value`
@@ -135,6 +175,34 @@ The background color of qrcode.
 - Default: `#000000`
 
 The foreground color of qrcode.
+
+### `gradient`
+
+- Type: `boolean`
+- Default: `false`
+
+Enable gradient fill for the QR code.
+
+### `gradient-type`
+
+- Type: `GradientType('linear' | 'radial')`
+- Default: `linear`
+
+Specify the type of gradient.
+
+### `gradient-start-color`
+
+- Type: `string`
+- Default: `#000000`
+
+The start color of the gradient.
+
+### `gradient-end-color`
+
+- Type: `string`
+- Default: `#ffffff`
+
+The end color of the gradient.
 
 ### `class`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,320 +1,335 @@
-import { defineComponent, h, onMounted, onUpdated, PropType, ref } from 'vue';
-import QR from './qrcodegen';
+import { defineComponent, h, onMounted, onUpdated, PropType, ref } from 'vue'
+import QR from './qrcodegen'
 
-type Modules = ReturnType<QR.QrCode['getModules']>;
-export type Level = 'L' | 'M' | 'Q' | 'H';
-export type RenderAs = 'canvas' | 'svg';
-export type GradientType = 'linear' | 'radial';
+type Modules = ReturnType<QR.QrCode['getModules']>
+export type Level = 'L' | 'M' | 'Q' | 'H'
+export type RenderAs = 'canvas' | 'svg'
+export type GradientType = 'linear' | 'radial'
 
-const defaultErrorCorrectLevel = 'H';
+const defaultErrorCorrectLevel = 'H'
 
 const ErrorCorrectLevelMap: Readonly<Record<Level, QR.QrCode.Ecc>> = {
-  L: QR.QrCode.Ecc.LOW,
-  M: QR.QrCode.Ecc.MEDIUM,
-  Q: QR.QrCode.Ecc.QUARTILE,
-  H: QR.QrCode.Ecc.HIGH,
-};
+	L: QR.QrCode.Ecc.LOW,
+	M: QR.QrCode.Ecc.MEDIUM,
+	Q: QR.QrCode.Ecc.QUARTILE,
+	H: QR.QrCode.Ecc.HIGH,
+}
 
 // Thanks the `qrcode.react`
 const SUPPORTS_PATH2D: boolean = (function () {
-  try {
-    new Path2D().addPath(new Path2D());
-  } catch (e) {
-    return false;
-  }
-  return true;
-})();
+	try {
+		new Path2D().addPath(new Path2D())
+	} catch (e) {
+		return false
+	}
+	return true
+})()
 
 function validErrorCorrectLevel(level: string): boolean {
-  return level in ErrorCorrectLevelMap;
+	return level in ErrorCorrectLevelMap
 }
 
 function generatePath(modules: Modules, margin: number = 0): string {
-  const ops: string[] = [];
-  modules.forEach(function (row, y) {
-    let start: number | null = null;
-    row.forEach(function (cell, x) {
-      if (!cell && start !== null) {
-        ops.push(
-          `M${start + margin} ${y + margin}h${x - start}v1H${start + margin}z`,
-        );
-        start = null;
-        return;
-      }
-      if (x === row.length - 1) {
-        if (!cell) return;
-        if (start === null) {
-          ops.push(`M${x + margin},${y + margin} h1v1H${x + margin}z`);
-        } else {
-          ops.push(
-            `M${start + margin},${y + margin} h${x + 1 - start}v1H${
-              start + margin
-            }z`,
-          );
-        }
-        return;
-      }
-      if (cell && start === null) {
-        start = x;
-      }
-    });
-  });
-  return ops.join('');
+	const ops: string[] = []
+	modules.forEach(function (row, y) {
+		let start: number | null = null
+		row.forEach(function (cell, x) {
+			if (!cell && start !== null) {
+				ops.push(
+					`M${start + margin} ${y + margin}h${x - start}v1H${start + margin}z`
+				)
+				start = null
+				return
+			}
+			if (x === row.length - 1) {
+				if (!cell) return
+				if (start === null) {
+					ops.push(`M${x + margin},${y + margin} h1v1H${x + margin}z`)
+				} else {
+					ops.push(
+						`M${start + margin},${y + margin} h${x + 1 - start}v1H${
+							start + margin
+						}z`
+					)
+				}
+				return
+			}
+			if (cell && start === null) {
+				start = x
+			}
+		})
+	})
+	return ops.join('')
 }
 
 const QRCodeProps = {
-  value: {
-    type: String,
-    required: true,
-    default: '',
-  },
-  size: {
-    type: Number,
-    default: 100,
-  },
-  level: {
-    type: String as PropType<Level>,
-    default: defaultErrorCorrectLevel,
-    validator: (l: any) => validErrorCorrectLevel(l),
-  },
-  background: {
-    type: String,
-    default: '#fff',
-  },
-  foreground: {
-    type: String,
-    default: '#000',
-  },
-  margin: {
-    type: Number,
-    required: false,
-    default: 0,
-  },
-  gradient: {
-    type: Boolean,
-    required: false,
-    default: false,
-  },
-  gradientType: {
-    type: String as PropType<GradientType>,
-    required: false,
-    default: 'linear',
-    validator: (t: any) => ['linear', 'radial'].indexOf(t) > -1,
-  },
-  gradientStartColor: {
-    type: String,
-    required: false,
-    default: '#000',
-  },
-  gradientEndColor: {
-    type: String,
-    required: false,
-    default: '#fff',
-  },
-};
+	value: {
+		type: String,
+		required: true,
+		default: '',
+	},
+	size: {
+		type: Number,
+		default: 100,
+	},
+	level: {
+		type: String as PropType<Level>,
+		default: defaultErrorCorrectLevel,
+		validator: (l: any) => validErrorCorrectLevel(l),
+	},
+	background: {
+		type: String,
+		default: '#fff',
+	},
+	foreground: {
+		type: String,
+		default: '#000',
+	},
+	margin: {
+		type: Number,
+		required: false,
+		default: 0,
+	},
+	gradient: {
+		type: Boolean,
+		required: false,
+		default: false,
+	},
+	gradientType: {
+		type: String as PropType<GradientType>,
+		required: false,
+		default: 'linear',
+		validator: (t: any) => ['linear', 'radial'].indexOf(t) > -1,
+	},
+	gradientStartColor: {
+		type: String,
+		required: false,
+		default: '#000',
+	},
+	gradientEndColor: {
+		type: String,
+		required: false,
+		default: '#fff',
+	},
+}
 
 const QRCodeVueProps = {
-  ...QRCodeProps,
-  renderAs: {
-    type: String as PropType<RenderAs>,
-    required: false,
-    default: 'canvas',
-    validator: (as: any) => ['canvas', 'svg'].indexOf(as) > -1,
-  },
-};
+	...QRCodeProps,
+	renderAs: {
+		type: String as PropType<RenderAs>,
+		required: false,
+		default: 'canvas',
+		validator: (as: any) => ['canvas', 'svg'].indexOf(as) > -1,
+	},
+}
 
 const QRCodeSvg = defineComponent({
-  name: 'QRCodeSvg',
-  props: QRCodeProps,
-  setup(props) {
-    const numCells = ref(0);
-    const fgPath = ref('');
+	name: 'QRCodeSvg',
+	props: QRCodeProps,
+	setup(props) {
+		const numCells = ref(0)
+		const fgPath = ref('')
 
-    const generate = () => {
-      const { value, level, margin } = props;
-      const cells = QR.QrCode.encodeText(
-        value,
-        ErrorCorrectLevelMap[level],
-      ).getModules();
-      numCells.value = cells.length + margin * 2;
-      fgPath.value = generatePath(cells, margin);
-    };
+		const generate = () => {
+			const { value, level, margin } = props
+			const cells = QR.QrCode.encodeText(
+				value,
+				ErrorCorrectLevelMap[level]
+			).getModules()
+			numCells.value = cells.length + margin * 2
+			fgPath.value = generatePath(cells, margin)
+		}
 
-    generate();
-    onUpdated(generate);
+		generate()
+		onUpdated(generate)
 
-    return () =>
-      h(
-        'svg',
-        {
-          width: props.size,
-          height: props.size,
-          'shape-rendering': `crispEdges`,
-          xmlns: 'http://www.w3.org/2000/svg',
-          viewBox: `0 0 ${numCells.value} ${numCells.value}`,
-        },
-        [
-          h(
-            'defs',
-            {},
-            props.gradient
-              ? h(
-                  props.gradientType === 'linear'
-                    ? 'linearGradient'
-                    : 'radialGradient',
-                  {
-                    id: 'grad',
-                    ...(props.gradientType === 'linear'
-                      ? { x1: '0%', y1: '0%', x2: '100%', y2: '100%' }
-                      : {
-                          cx: '50%',
-                          cy: '50%',
-                          r: '50%',
-                          fx: '50%',
-                          fy: '50%',
-                        }),
-                  },
-                  [
-                    h('stop', {
-                      offset: '0%',
-                      style: { stopColor: props.gradientStartColor },
-                    }),
-                    h('stop', {
-                      offset: '100%',
-                      style: { stopColor: props.gradientEndColor },
-                    }),
-                  ],
-                )
-              : h(''),
-          ),
-          h('rect', { width: '100%', height: '100%', fill: props.background }),
-          h('path', {
-            fill: props.gradient ? 'url(#grad)' : props.foreground,
-            d: fgPath.value,
-          }),
-        ],
-      );
-  },
-});
+		return () =>
+			h(
+				'svg',
+				{
+					width: props.size,
+					height: props.size,
+					'shape-rendering': `crispEdges`,
+					xmlns: 'http://www.w3.org/2000/svg',
+					viewBox: `0 0 ${numCells.value} ${numCells.value}`,
+				},
+				[
+					h(
+						'defs',
+						{},
+						props.gradient
+							? h(
+									props.gradientType === 'linear'
+										? 'linearGradient'
+										: 'radialGradient',
+									{
+										id: 'grad',
+										...(props.gradientType === 'linear'
+											? {
+													x1: '0%',
+													y1: '0%',
+													x2: '100%',
+													y2: '100%',
+												}
+											: {
+													cx: '50%',
+													cy: '50%',
+													r: '50%',
+													fx: '50%',
+													fy: '50%',
+												}),
+									},
+									[
+										h('stop', {
+											offset: '0%',
+											style: {
+												stopColor:
+													props.gradientStartColor,
+											},
+										}),
+										h('stop', {
+											offset: '100%',
+											style: {
+												stopColor:
+													props.gradientEndColor,
+											},
+										}),
+									]
+								)
+							: h('')
+					),
+					h('rect', {
+						width: '100%',
+						height: '100%',
+						fill: props.background,
+					}),
+					h('path', {
+						fill: props.gradient ? 'url(#grad)' : props.foreground,
+						d: fgPath.value,
+					}),
+				]
+			)
+	},
+})
 
 const QRCodeCanvas = defineComponent({
-  name: 'QRCodeCanvas',
-  props: QRCodeProps,
-  setup(props) {
-    const canvasEl = ref<HTMLCanvasElement | null>(null);
+	name: 'QRCodeCanvas',
+	props: QRCodeProps,
+	setup(props) {
+		const canvasEl = ref<HTMLCanvasElement | null>(null)
 
-    const generate = () => {
-      const {
-        value,
-        level,
-        size,
-        margin,
-        background,
-        foreground,
-        gradient,
-        gradientType,
-        gradientStartColor,
-        gradientEndColor,
-      } = props;
-      const canvas = canvasEl.value;
-      if (!canvas) return;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) return;
+		const generate = () => {
+			const {
+				value,
+				level,
+				size,
+				margin,
+				background,
+				foreground,
+				gradient,
+				gradientType,
+				gradientStartColor,
+				gradientEndColor,
+			} = props
+			const canvas = canvasEl.value
+			if (!canvas) return
+			const ctx = canvas.getContext('2d')
+			if (!ctx) return
 
-      const cells = QR.QrCode.encodeText(
-        value,
-        ErrorCorrectLevelMap[level],
-      ).getModules();
-      const numCells = cells.length + margin * 2;
-      const devicePixelRatio = window.devicePixelRatio || 1;
-      const scale = (size / numCells) * devicePixelRatio;
-      canvas.height = canvas.width = size * devicePixelRatio;
-      ctx.scale(scale, scale);
+			const cells = QR.QrCode.encodeText(
+				value,
+				ErrorCorrectLevelMap[level]
+			).getModules()
+			const numCells = cells.length + margin * 2
+			const devicePixelRatio = window.devicePixelRatio || 1
+			const scale = (size / numCells) * devicePixelRatio
+			canvas.height = canvas.width = size * devicePixelRatio
+			ctx.scale(scale, scale)
 
-      ctx.fillStyle = background;
-      ctx.fillRect(0, 0, numCells, numCells);
+			ctx.fillStyle = background
+			ctx.fillRect(0, 0, numCells, numCells)
 
-      if (gradient) {
-        let grad;
-        if (gradientType === 'linear') {
-          grad = ctx.createLinearGradient(0, 0, numCells, numCells);
-        } else {
-          grad = ctx.createRadialGradient(
-            numCells / 2,
-            numCells / 2,
-            0,
-            numCells / 2,
-            numCells / 2,
-            numCells / 2,
-          );
-        }
-        grad.addColorStop(0, gradientStartColor);
-        grad.addColorStop(1, gradientEndColor);
-        ctx.fillStyle = grad;
-      } else {
-        ctx.fillStyle = foreground;
-      }
+			if (gradient) {
+				let grad
+				if (gradientType === 'linear') {
+					grad = ctx.createLinearGradient(0, 0, numCells, numCells)
+				} else {
+					grad = ctx.createRadialGradient(
+						numCells / 2,
+						numCells / 2,
+						0,
+						numCells / 2,
+						numCells / 2,
+						numCells / 2
+					)
+				}
+				grad.addColorStop(0, gradientStartColor)
+				grad.addColorStop(1, gradientEndColor)
+				ctx.fillStyle = grad
+			} else {
+				ctx.fillStyle = foreground
+			}
 
-      if (SUPPORTS_PATH2D) {
-        ctx.fill(new Path2D(generatePath(cells, margin)));
-      } else {
-        cells.forEach(function (row, rdx) {
-          row.forEach(function (cell, cdx) {
-            if (cell) {
-              ctx.fillRect(cdx + margin, rdx + margin, 1, 1);
-            }
-          });
-        });
-      }
-    };
+			if (SUPPORTS_PATH2D) {
+				ctx.fill(new Path2D(generatePath(cells, margin)))
+			} else {
+				cells.forEach(function (row, rdx) {
+					row.forEach(function (cell, cdx) {
+						if (cell) {
+							ctx.fillRect(cdx + margin, rdx + margin, 1, 1)
+						}
+					})
+				})
+			}
+		}
 
-    onMounted(generate);
-    onUpdated(generate);
+		onMounted(generate)
+		onUpdated(generate)
 
-    return () =>
-      h('canvas', {
-        ref: canvasEl,
-        style: { width: `${props.size}px`, height: `${props.size}px` },
-      });
-  },
-});
+		return () =>
+			h('canvas', {
+				ref: canvasEl,
+				style: { width: `${props.size}px`, height: `${props.size}px` },
+			})
+	},
+})
 
 const QrcodeVue = defineComponent({
-  name: 'Qrcode',
-  render() {
-    const {
-      renderAs,
-      value,
-      size: _size,
-      margin: _margin,
-      level: _level,
-      background,
-      foreground,
-      gradient,
-      gradientType,
-      gradientStartColor,
-      gradientEndColor,
-    } = this.$props;
-    const size = _size >>> 0;
-    const margin = _margin >>> 0;
-    const level = validErrorCorrectLevel(_level)
-      ? _level
-      : defaultErrorCorrectLevel;
+	name: 'Qrcode',
+	render() {
+		const {
+			renderAs,
+			value,
+			size: _size,
+			margin: _margin,
+			level: _level,
+			background,
+			foreground,
+			gradient,
+			gradientType,
+			gradientStartColor,
+			gradientEndColor,
+		} = this.$props
+		const size = _size >>> 0
+		const margin = _margin >>> 0
+		const level = validErrorCorrectLevel(_level)
+			? _level
+			: defaultErrorCorrectLevel
 
-    return h(renderAs === 'svg' ? QRCodeSvg : QRCodeCanvas, {
-      value,
-      size,
-      margin,
-      level,
-      background,
-      foreground,
-      gradient,
-      gradientType,
-      gradientStartColor,
-      gradientEndColor,
-    });
-  },
-  props: QRCodeVueProps,
-});
+		return h(renderAs === 'svg' ? QRCodeSvg : QRCodeCanvas, {
+			value,
+			size,
+			margin,
+			level,
+			background,
+			foreground,
+			gradient,
+			gradientType,
+			gradientStartColor,
+			gradientEndColor,
+		})
+	},
+	props: QRCodeVueProps,
+})
 
-export default QrcodeVue;
+export default QrcodeVue

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import { defineComponent, h, onMounted, onUpdated, PropType, ref } from "vue";
-import QR from "./qrcodegen";
+import { defineComponent, h, onMounted, onUpdated, PropType, ref } from 'vue';
+import QR from './qrcodegen';
 
-type Modules = ReturnType<QR.QrCode["getModules"]>;
-export type Level = "L" | "M" | "Q" | "H";
-export type RenderAs = "canvas" | "svg";
-export type GradientType = "linear" | "radial";
+type Modules = ReturnType<QR.QrCode['getModules']>;
+export type Level = 'L' | 'M' | 'Q' | 'H';
+export type RenderAs = 'canvas' | 'svg';
+export type GradientType = 'linear' | 'radial';
 
-const defaultErrorCorrectLevel = "H";
+const defaultErrorCorrectLevel = 'H';
 
 const ErrorCorrectLevelMap: Readonly<Record<Level, QR.QrCode.Ecc>> = {
   L: QR.QrCode.Ecc.LOW,
@@ -59,14 +59,14 @@ function generatePath(modules: Modules, margin: number = 0): string {
       }
     });
   });
-  return ops.join("");
+  return ops.join('');
 }
 
 const QRCodeProps = {
   value: {
     type: String,
     required: true,
-    default: "",
+    default: '',
   },
   size: {
     type: Number,
@@ -79,11 +79,11 @@ const QRCodeProps = {
   },
   background: {
     type: String,
-    default: "#fff",
+    default: '#fff',
   },
   foreground: {
     type: String,
-    default: "#000",
+    default: '#000',
   },
   margin: {
     type: Number,
@@ -98,18 +98,18 @@ const QRCodeProps = {
   gradientType: {
     type: String as PropType<GradientType>,
     required: false,
-    default: "linear",
-    validator: (t: any) => ["linear", "radial"].indexOf(t) > -1,
+    default: 'linear',
+    validator: (t: any) => ['linear', 'radial'].indexOf(t) > -1,
   },
   gradientStartColor: {
     type: String,
     required: false,
-    default: "#000",
+    default: '#000',
   },
   gradientEndColor: {
     type: String,
     required: false,
-    default: "#fff",
+    default: '#fff',
   },
 };
 
@@ -118,17 +118,17 @@ const QRCodeVueProps = {
   renderAs: {
     type: String as PropType<RenderAs>,
     required: false,
-    default: "canvas",
-    validator: (as: any) => ["canvas", "svg"].indexOf(as) > -1,
+    default: 'canvas',
+    validator: (as: any) => ['canvas', 'svg'].indexOf(as) > -1,
   },
 };
 
 const QRCodeSvg = defineComponent({
-  name: "QRCodeSvg",
+  name: 'QRCodeSvg',
   props: QRCodeProps,
   setup(props) {
     const numCells = ref(0);
-    const fgPath = ref("");
+    const fgPath = ref('');
 
     const generate = () => {
       const { value, level, margin } = props;
@@ -145,51 +145,51 @@ const QRCodeSvg = defineComponent({
 
     return () =>
       h(
-        "svg",
+        'svg',
         {
           width: props.size,
           height: props.size,
-          "shape-rendering": `crispEdges`,
-          xmlns: "http://www.w3.org/2000/svg",
+          'shape-rendering': `crispEdges`,
+          xmlns: 'http://www.w3.org/2000/svg',
           viewBox: `0 0 ${numCells.value} ${numCells.value}`,
         },
         [
           h(
-            "defs",
+            'defs',
             {},
             props.gradient
               ? h(
-                  props.gradientType === "linear"
-                    ? "linearGradient"
-                    : "radialGradient",
+                  props.gradientType === 'linear'
+                    ? 'linearGradient'
+                    : 'radialGradient',
                   {
-                    id: "grad",
-                    ...(props.gradientType === "linear"
-                      ? { x1: "0%", y1: "0%", x2: "100%", y2: "100%" }
+                    id: 'grad',
+                    ...(props.gradientType === 'linear'
+                      ? { x1: '0%', y1: '0%', x2: '100%', y2: '100%' }
                       : {
-                          cx: "50%",
-                          cy: "50%",
-                          r: "50%",
-                          fx: "50%",
-                          fy: "50%",
+                          cx: '50%',
+                          cy: '50%',
+                          r: '50%',
+                          fx: '50%',
+                          fy: '50%',
                         }),
                   },
                   [
-                    h("stop", {
-                      offset: "0%",
+                    h('stop', {
+                      offset: '0%',
                       style: { stopColor: props.gradientStartColor },
                     }),
-                    h("stop", {
-                      offset: "100%",
+                    h('stop', {
+                      offset: '100%',
                       style: { stopColor: props.gradientEndColor },
                     }),
                   ],
                 )
-              : h(""),
+              : h(''),
           ),
-          h("rect", { width: "100%", height: "100%", fill: props.background }),
-          h("path", {
-            fill: props.gradient ? "url(#grad)" : props.foreground,
+          h('rect', { width: '100%', height: '100%', fill: props.background }),
+          h('path', {
+            fill: props.gradient ? 'url(#grad)' : props.foreground,
             d: fgPath.value,
           }),
         ],
@@ -198,7 +198,7 @@ const QRCodeSvg = defineComponent({
 });
 
 const QRCodeCanvas = defineComponent({
-  name: "QRCodeCanvas",
+  name: 'QRCodeCanvas',
   props: QRCodeProps,
   setup(props) {
     const canvasEl = ref<HTMLCanvasElement | null>(null);
@@ -218,7 +218,7 @@ const QRCodeCanvas = defineComponent({
       } = props;
       const canvas = canvasEl.value;
       if (!canvas) return;
-      const ctx = canvas.getContext("2d");
+      const ctx = canvas.getContext('2d');
       if (!ctx) return;
 
       const cells = QR.QrCode.encodeText(
@@ -236,7 +236,7 @@ const QRCodeCanvas = defineComponent({
 
       if (gradient) {
         let grad;
-        if (gradientType === "linear") {
+        if (gradientType === 'linear') {
           grad = ctx.createLinearGradient(0, 0, numCells, numCells);
         } else {
           grad = ctx.createRadialGradient(
@@ -272,7 +272,7 @@ const QRCodeCanvas = defineComponent({
     onUpdated(generate);
 
     return () =>
-      h("canvas", {
+      h('canvas', {
         ref: canvasEl,
         style: { width: `${props.size}px`, height: `${props.size}px` },
       });
@@ -280,7 +280,7 @@ const QRCodeCanvas = defineComponent({
 });
 
 const QrcodeVue = defineComponent({
-  name: "Qrcode",
+  name: 'Qrcode',
   render() {
     const {
       renderAs,
@@ -301,7 +301,7 @@ const QrcodeVue = defineComponent({
       ? _level
       : defaultErrorCorrectLevel;
 
-    return h(renderAs === "svg" ? QRCodeSvg : QRCodeCanvas, {
+    return h(renderAs === 'svg' ? QRCodeSvg : QRCodeCanvas, {
       value,
       size,
       margin,


### PR DESCRIPTION
Here's a sample message for a pull request to add the gradient support feature to the `qrcode.vue` component:

---

### Add Gradient Support to QRCodeVue Component

#### Summary

This PR introduces gradient support for the `qrcode.vue` component, allowing users to generate QR codes with gradient fills. The enhancement includes new props to configure gradient types and colors, applicable to both SVG and Canvas renderings.

#### Changes

1. **New Props**:
    - `gradient`: Boolean to enable/disable gradient fill.
    - `gradientType`: Type of gradient (`linear` or `radial`).
    - `gradientStartColor`: Start color of the gradient.
    - `gradientEndColor`: End color of the gradient.

2. **SVG Renderer**:
    - Added gradient definitions in the SVG output.
    - Applied gradient fill to the QR code path.

3. **Canvas Renderer**:
    - Created gradient objects using `createLinearGradient` or `createRadialGradient`.
    - Applied gradient fill to the QR code rectangles.

#### Usage Examples

**Without Gradient**:
```vue
<template>
  <qrcode-vue
    :size="size"
    :value="fullUrl"
    :level="level"
    :margin="margin"
    :render-as="renderAs"
    :background="background"
    :foreground="foreground"
  />
</template>

<script>
export default {
  data() {
    return {
      size: 200,
      fullUrl: 'https://example.com',
      level: 'H',
      margin: 4,
      renderAs: 'svg', // or 'canvas'
      background: '#ffffff',
      foreground: '#000000',
    }
  },
}
</script>
```

**With Gradient**:
```vue
<template>
  <qrcode-vue
    :size="size"
    :value="fullUrl"
    :level="level"
    :margin="margin"
    :render-as="renderAs"
    :background="background"
    :gradient="true"
    :gradient-type="gradientType"
    :gradient-start-color="gradientStartColor"
    :gradient-end-color="gradientEndColor"
  />
</template>

<script>
export default {
  data() {
    return {
      size: 200,
      fullUrl: 'https://example.com',
      level: 'H',
      margin: 4,
      renderAs: 'svg', // or 'canvas'
      background: '#ffffff',
      gradient: true,
      gradientType: 'linear', // or 'radial'
      gradientStartColor: '#ff0000', // Start color of the gradient
      gradientEndColor: '#0000ff', // End color of the gradient
    }
  },
}
</script>
```

#### Documentation

Updated the `README.md` to include the new props and usage examples for both plain color and gradient QR codes.

#### Testing

- Verified that the gradient properties work correctly for both SVG and Canvas renderings.
- Ensured backward compatibility with existing usage that does not utilize gradient features.

#### Review

Please review the changes and provide feedback. Looking forward to your comments and suggestions.

Thank you!